### PR TITLE
Fix integer division in gauss_kernel.

### DIFF
--- a/spykeutils/rate_estimation.py
+++ b/spykeutils/rate_estimation.py
@@ -171,7 +171,7 @@ def minimum_spike_train_interval(trains):
 
 def gauss_kernel(x, kernel_size):
     return 1.0 / (sp.sqrt(2*sp.pi) * kernel_size) * \
-           sp.exp(-1/2 *  (x / kernel_size)**2)
+           sp.exp(-0.5 *  (x / kernel_size)**2)
 
 
 def _hist_density(hist, kernel, ksize, start, stop):


### PR DESCRIPTION
-1/2 = -1 and not -0.5 in Python
